### PR TITLE
feat: added ability to customize the onChange behavior by choosing between throttle and debounce and by specifying a duration

### DIFF
--- a/.changeset/shiny-pots-applaud.md
+++ b/.changeset/shiny-pots-applaud.md
@@ -1,0 +1,5 @@
+---
+"@neocodemirror/svelte": patch
+---
+
+added ability to customize the onChange behavior by choosing between throttle and debounce and by specifying a duration

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -407,7 +407,7 @@ export const codemirror = (
 
 	const { kind: behaviorKind = 'debounce', duration: behaviorDuration = 50 } = onChangeBehavior;
 
-	const on_change = behaviorKind === 'debounce' ? 
+	let on_change = behaviorKind === 'debounce' ? 
 		debounce(handle_change, behaviorDuration) : 
 		throttle(handle_change, behaviorDuration);
 
@@ -515,6 +515,15 @@ export const codemirror = (
 				extensions: internal_extensions,
 				value,
 			});
+
+			const { kind: behaviorKind = 'debounce', duration: behaviorDuration = 50 } = 
+				new_options.onChangeBehavior ?? { kind: 'debounce', duration: 50 };
+		
+			if(options.onChangeBehavior?.kind !== behaviorKind || options.onChangeBehavior.duration !== behaviorDuration){
+				on_change = behaviorKind === 'debounce' ? 
+					debounce(handle_change, behaviorDuration) : 
+					throttle(handle_change, behaviorDuration);
+			}
 
 			options = new_options;
 		},


### PR DESCRIPTION
As we talked on twitter this PR adds the ability to both customize the duration of the debounce or to swap the debounce function with the throttle one.

I've avoided the throttle dependency and updated the options typings.

Also i've tested this and it should work correctly (at least from what i expect)

P.s. Sorry for the multi commit, i think vscode did something stupid :D