### PR TITLE
(feat) add document mode

### DIFF
--- a/.changeset/smart-trees-think.md
+++ b/.changeset/smart-trees-think.md
@@ -1,0 +1,5 @@
+---
+'@neocodemirror/svelte': patch
+---
+
+Add document mode, where you can specify a documentId to tie the specific editor state to that documentId (useful for multitab applications)

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+	"singleQuote": true,
+	"printWidth": 100,
+	"useTabs": true,
+	"trailingComma": "es5"
+}

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -40,3 +40,41 @@ Getting editor related data
 ```
 
 Note: Passing the store recieved from `withCodemirrorInstance` is required to get the editor related data. If you don't pass this store, you will not get any data.
+
+## Document mode
+
+If you pass a `documentId` in the options you'll automatically enter document mode. In this mode whenever the `documentId` changes the state of the editor get's stored in a map and will later be restored when the `documentId` changes again. This allows for the history to be `documentId` contained (so for example if you change documentId and try to Ctrl+Z or Cmd+Z it will not work). Right before this swap and right after two events `on:codemirror:documentChanging` and `on:codemirror:documentChanged` will be fired. This allows you to store additional state that might not be serializable in the codemirror state.
+
+```svelte
+<script>
+  import { codemirror } from '@neocodemirror/svelte'
+  import { javascript } from '@codemirror/lang-javascript'
+
+  const documents = [
+	{
+		title: '+page.svelte',
+		content: '<scri lang="ts">export let data</scri'++'pt> {data.name}'
+	},
+	{
+		title: '+page.js',
+		content: 'export function load(){ return {name: "neocodemirror"} }'
+	},
+  ];
+
+  let selected_document = 0;
+</script>
+
+{#each documents as document, i}
+	<button on:click={()=> selected_document=i}>{document.title}</button>
+{/each}
+
+<div 
+	on:codemirror:changeText={(new_text)=>{
+		documents[selected_document].content=new_text;
+	}}
+	use:codemirror={{ 
+		value: documents[selected_document].content, 
+		documentId: documents[selected_document].title
+	}} 
+/>
+```

--- a/packages/svelte/demo/src/routes/+page.svelte
+++ b/packages/svelte/demo/src/routes/+page.svelte
@@ -67,6 +67,12 @@
 </select>
 
 <div
+	on:codemirror:documentChanged={() => {
+		console.log('document changed on div');
+	}}
+	on:codemirror:documentChanging={() => {
+		console.log('document changing on div');
+	}}
 	use:codemirror={{
 		value: options[selected].value,
 		setup,
@@ -90,6 +96,13 @@
 		onTextChange(value) {
 			console.log(value);
 			options[selected].value = value;
+		},
+		documentId: selected,
+		onDocumentChanged() {
+			console.log('document changed in options');
+		},
+		onDocumentChanging() {
+			console.log('document changing in options');
 		},
 	}}
 />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -92,7 +96,7 @@ importers:
         version: 5.0.4
       vite:
         specifier: ^4.3.8
-        version: 4.3.8(terser@5.17.4)
+        version: 4.3.8
 
 packages:
 
@@ -806,13 +810,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/source-map@0.3.3:
-    resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
-    dev: true
-
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
     dev: true
@@ -1034,7 +1031,7 @@ packages:
       svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.1
-      vite: 4.3.8(terser@5.17.4)
+      vite: 4.3.8
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1052,7 +1049,7 @@ packages:
       magic-string: 0.30.0
       svelte: 3.59.1
       svelte-hmr: 0.15.1(svelte@3.59.1)
-      vite: 4.3.8(terser@5.17.4)
+      vite: 4.3.8
       vitefu: 0.2.4(vite@4.3.8)
     transitivePeerDependencies:
       - supports-color
@@ -1086,12 +1083,6 @@ packages:
 
   /@types/semver@6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
-    dev: true
-
-  /acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: true
 
   /ansi-colors@4.1.3:
@@ -1206,10 +1197,6 @@ packages:
 
   /buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-    dev: true
-
-  /buffer-from@1.1.2:
-    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
 
   /bundle-require@4.0.1(esbuild@0.17.19):
@@ -1342,10 +1329,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
-
-  /commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
   /commander@4.1.1:
@@ -2800,18 +2783,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /source-map-support@0.5.21:
-    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
-    dependencies:
-      buffer-from: 1.1.2
-      source-map: 0.6.1
-    dev: true
-
-  /source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
@@ -3051,17 +3022,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /terser@5.17.4:
-    resolution: {integrity: sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/source-map': 0.3.3
-      acorn: 8.8.2
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    dev: true
-
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -3232,7 +3192,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite@4.3.8(terser@5.17.4):
+  /vite@4.3.8:
     resolution: {integrity: sha512-uYB8PwN7hbMrf4j1xzGDk/lqjsZvCDbt/JC5dyfxc19Pg8kRm14LinK/uq+HSLNswZEoKmweGdtpbnxRtrAXiQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -3260,7 +3220,6 @@ packages:
       esbuild: 0.17.19
       postcss: 8.4.23
       rollup: 3.22.0
-      terser: 5.17.4
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -3273,7 +3232,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.3.8(terser@5.17.4)
+      vite: 4.3.8
     dev: true
 
   /w3c-keyname@2.2.7:


### PR DESCRIPTION
This PR add document mode to this package.

This allows the user to pass a documentId to the options. If it's passed when the documentId changes the state of the editor (history included) get's stored in a Map so that when later the documentId get's changed back the state get's applied again. This is useful for multi tabs applications like, i don't know the svelte repl or sveltelab.

Just before changing the state and just after two events get's triggered `on:codemirror:documentChanging` and `on:codemirror:documentChanged` this allows the user to store some state that might not be serializable (looking at you vim).

I've also added .prettierc.json

Some notes:

1. Should we pass the view to the documentChanging/documentChanged callbacks? I assumed if someone need to get the view can always use the store but maybe as a convenience we could pass the view in.
2. the setState needs to be sent after the normal transaction get's dispatched. This means that the doc actually changes two times. Preventing this might make the code a bit unmantainable but that is undeniably extra work that maybe we could avoid... @PuruVJ wdyt?