### PR TITLE
feat: Remove on* callbacks, dont use dispatch lifecycle, cursor autofocus

### DIFF
--- a/packages/svelte/demo/src/routes/+page.svelte
+++ b/packages/svelte/demo/src/routes/+page.svelte
@@ -37,7 +37,7 @@
 
 	let selected: keyof typeof options = 'svelte';
 
-	let cursorPos = 40;
+	let cursorPos = 0;
 
 	let diagnostics: Diagnostic[] = [];
 
@@ -87,10 +87,10 @@
 		cursorPos,
 		diagnostics: diagnostics,
 		instanceStore: store,
-		onTextChange(value) {
-			console.log(value);
-			options[selected].value = value;
-		},
+	}}
+	on:codemirror:textChange={({ detail: value }) => {
+		console.log(value);
+		options[selected].value = value;
 	}}
 />
 

--- a/packages/svelte/demo/vite.config.ts
+++ b/packages/svelte/demo/vite.config.ts
@@ -3,9 +3,9 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [sveltekit()],
-	// resolve: {
-	// 	dedupe: ['@codemirror/state'],
-	// },
+	resolve: {
+		dedupe: ['@codemirror/state'],
+	},
 	// optimizeDeps: {
 	// 	// exclude: ['@codemirror/state'],
 	// 	include: ['@codemirror/state'],

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -404,7 +404,7 @@ export const codemirror = (
 		make_diagnostics(view, diagnostics);
 
 		// Focus the editor if the cursor position is set
-		if (options.cursorPos) view.focus();
+		if (!is_undefined(options.cursorPos)) view.focus();
 
 		instanceStore?.set({
 			view: view,


### PR DESCRIPTION
- Removes on* handlers. Having them can sometimes cause infinite loop of update cycle. Instead Svelte language tools should be improved
- Instead of calling `on_change` in dispatch, this makes it a bit more async and calls it as a ViewUpdate listener extension
- Autofocus if cursorPos changed or initially not 0